### PR TITLE
Fix program to work on 64-bit architecture

### DIFF
--- a/src/com/elsdoerfer/android/autostarts/ToggleTool.java
+++ b/src/com/elsdoerfer/android/autostarts/ToggleTool.java
@@ -144,7 +144,21 @@ class ToggleTool {
 				// On ICS, it became necessary to set a library path (which is
 				// cleared for suid programs, for obvious reasons). It can't hurt
 				// on older versions. See also  https://github.com/ChainsDD/su-binary/issues/6
-				final String libs = "LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:/system/lib\" ";
+				
+				String abi = null; //check if the architecture is 32 or 64bits
+				if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+					abi = Build.CPU_ABI;
+				} else {
+					abi = Build.SUPPORTED_ABIS[0];
+				}
+				final String libs;
+				if (abi.equals("arm64-v8a") || abi.equals("x86_64") || abi.equals("mips64")) {
+					libs = "LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:/system/lib64\" ";
+				}
+				else {
+					libs = "LD_LIBRARY_PATH=\"$LD_LIBRARY_PATH:/system/lib\" ";
+				}
+				
 				boolean success = false;
 				for (String[] set : new String[][] {
 						{ libs+"pm %s '%s/%s'", null },


### PR DESCRIPTION
When calling the root command, on 64-bit architecture, it didn't find the correspondent /system/lib64/ folder, still looking for /system/lib.
Now, it checks the architecture and set the folder accordingly.
