### PR TITLE
Add Link To F-Droid & Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,14 @@ Android Autostarts management utility
 [![BundleCop](https://api.bundlecop.com/badge/268318521568755716.svg?file=Android-Autostarts-Full.apk&label=APK%20Size)](https://app.bundlecop.com/project/268318521535987716)
 
 Website
-    http://elsdoerfer.name/=android-autostarts
 
-Google Play Store
-    https://play.google.com/store/apps/details?id=com.elsdoerfer.android.autostarts
+ * http://elsdoerfer.name/=android-autostarts
+
+App
+
+ * F-Droid https://f-droid.org/en/packages/com.elsdoerfer.android.autostarts/
+ * Google Play Store https://play.google.com/store/apps/details?id=com.elsdoerfer.android.autostarts
 
 Translations
-    http://www.transifex.net/projects/p/android-autostarts/
+
+ * http://www.transifex.net/projects/p/android-autostarts/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-Android Autostarts management utility
--------------------------------------
+Android Autostarts Management Utility (AAMU)
+--------------------------------------------
 
 [![BundleCop](https://api.bundlecop.com/badge/268318521568755716.svg?file=Android-Autostarts-Full.apk&label=APK%20Size)](https://app.bundlecop.com/project/268318521535987716)
 
@@ -9,9 +9,22 @@ Website
 
 App
 
- * F-Droid https://f-droid.org/en/packages/com.elsdoerfer.android.autostarts/
- * Google Play Store https://play.google.com/store/apps/details?id=com.elsdoerfer.android.autostarts
+ * F-Droid<sup>1</sup> https://f-droid.org/en/packages/com.elsdoerfer.android.autostarts/
+ * Google Play Store<sup>2</sup> https://play.google.com/store/apps/details?id=com.elsdoerfer.android.autostarts
+
+Legend
+
+ * <sup>1</sup>This F-Droid release is managed by a third party. The author of AAMU is aware of this third party release, thankful for it, but cannot vouch for it. Related discussion at https://github.com/miracle2k/android-autostarts/issues/39
+ * <sup>2</sup>This Google Play release is managed by the author of AAMU
+
+Support & Contribute
+
+ * https://github.com/miracle2k/android-autostarts/issues
 
 Translations
 
  * http://www.transifex.net/projects/p/android-autostarts/
+
+License
+
+ * GPL 3 https://github.com/miracle2k/android-autostarts/blob/master/LICENSE

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ App
 Legend
 
  * <sup>1</sup>This F-Droid release is managed by a third party. The author of AAMU is aware of this third party release, thankful for it, but cannot vouch for it. Related discussion at https://github.com/miracle2k/android-autostarts/issues/39
- * <sup>2</sup>This Google Play release is managed by the author of AAMU
+ * <sup>2</sup>This Google Play release is managed by the author of AAMU.
 
 Support & Contribute
 


### PR DESCRIPTION
## If applied, this commit will:

### Clarify F-Droid 3rd Party Release.
  This is per miracle2k at https://github.com/miracle2k/android-autostarts/pull/40#issuecomment-878924107
For easier reading, and reduce risk of cluttered, I suggest adding the details into the "Legend" group.



### Add Abbreviation AAMU.
To both reduce risk of clutter, and facilitate reading, I suggest adding this abbreviation. Which means Android Autostarts Management Utility (AAMU)



### Add "Support & Contribute" Group.
I suggest adding this group to both invite and facilitate contribution to autostarts



### Add "License" Group.
I suggest adding this group as it is a frequently asked question

### Add Minor Text Formatting